### PR TITLE
Simulate what the bind-service command in readme does but in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,10 @@
 ---
 applications:
 - name: jbp-oom-example
+  buildpacks:
+  - java_buildpack_offline
   memory: 1300m
   services:
-    - heap-dump
+    - name: heap-dump
+      parameters:
+        mount: /var/heap-dump


### PR DESCRIPTION
When using the cf7 cli you should be able to pass services parameters via the app manifest.